### PR TITLE
Fixes in minidumper

### DIFF
--- a/MiniDumper/Debugger.cs
+++ b/MiniDumper/Debugger.cs
@@ -86,6 +86,12 @@ namespace MiniDumper
                                     miniDumper.DumpOnException((uint)debugEvent.Value.dwThreadId, exception.ExceptionRecord);
                                 }
                                 break;
+                            case DEBUG_EVENT_CODE.OUTPUT_DEBUG_STRING_EVENT:
+                                if (_options.Verbose)
+                                {
+                                    miniDumper.PrintDebugString(debugEvent.Value.DebugString);
+                                }
+                                break;
                             default:
                                 break;
                         }

--- a/MiniDumper/Debugger.cs
+++ b/MiniDumper/Debugger.cs
@@ -226,7 +226,7 @@ namespace MiniDumper
         void ShowBanner()
         {
             Console.WriteLine("MiniDumper - writes .NET process dump files");
-            Console.WriteLine("Copyright (C) 2015 Sasha Goldstein (@goldshtn)");
+            Console.WriteLine("Copyright (C) 2018 Sasha Goldstein (@goldshtn)");
             Console.WriteLine();
             Console.WriteLine("With contributions from Sebastian Solnica (@lowleveldesign)");
             Console.WriteLine();

--- a/MiniDumper/Debugger.cs
+++ b/MiniDumper/Debugger.cs
@@ -38,8 +38,7 @@ namespace MiniDumper
             ValidateOptions(options);
             _options = options;
             _logger = options.Verbose ? Console.Out : TextWriter.Null;
-            _dumpFolder = options.DumpFolderForNewlyStartedProcess ?? Path.GetDirectoryName(
-                Process.GetCurrentProcess().MainModule.FileName);
+            _dumpFolder = options.DumpFolderForNewlyStartedProcess ?? Directory.GetCurrentDirectory();
         }
 
         void TakeDumps()

--- a/MiniDumper/MiniDumper.cs
+++ b/MiniDumper/MiniDumper.cs
@@ -75,6 +75,7 @@ namespace MiniDumper
 
         public void DumpOnException(uint threadId, EXCEPTION_RECORD ev)
         {
+            if (ev.ExceptionCode == BREAKPOINT_CODE)
             {
                 return;
             }

--- a/MiniDumper/MiniDumper.cs
+++ b/MiniDumper/MiniDumper.cs
@@ -154,24 +154,26 @@ namespace MiniDumper
 
         public void PrintDebugString(OUTPUT_DEBUG_STRING_INFO outputDbgStrInfo)
         {
-            SafeProcessHandle hProcess = Process.OpenProcess(ProcessAccessFlags.VmRead, false, pid);
-            if (hProcess.IsInvalid)
-                throw new ArgumentException(String.Format("Unable to open process {0}, error {x:8}", pid, Marshal.GetLastWin32Error()));
-
-            var dbgString = new byte[outputDbgStrInfo.nDebugStringLength];
-
-            uint numberOfBytesRead;
-            Process.ReadProcessMemory(hProcess, outputDbgStrInfo.lpDebugStringData, dbgString, outputDbgStrInfo.nDebugStringLength, out numberOfBytesRead);
-
-            if (numberOfBytesRead > 0)
+            using (SafeProcessHandle hProcess = Process.OpenProcess(ProcessAccessFlags.VmRead, false, pid))
             {
-                if (outputDbgStrInfo.fUnicode == 0)
+                if (hProcess.IsInvalid)
+                    throw new ArgumentException(String.Format("Unable to open process {0}, error {x:8}", pid, Marshal.GetLastWin32Error()));
+
+                var dbgString = new byte[outputDbgStrInfo.nDebugStringLength];
+
+                uint numberOfBytesRead;
+                var result = Process.ReadProcessMemory(hProcess, outputDbgStrInfo.lpDebugStringData, dbgString, outputDbgStrInfo.nDebugStringLength, out numberOfBytesRead);
+
+                if (result)
                 {
-                    Console.WriteLine("Debug String:\n {0}", Encoding.ASCII.GetString(dbgString));
-                }
-                else
-                {
-                    Console.WriteLine("Debug String:\n {0}", Encoding.Unicode.GetString(dbgString));
+                    if (outputDbgStrInfo.fUnicode == 0)
+                    {
+                        Console.WriteLine("Debug String: {0}", Encoding.ASCII.GetString(dbgString));
+                    }
+                    else
+                    {
+                        Console.WriteLine("Debug String: {0}", Encoding.Unicode.GetString(dbgString));
+                    }
                 }
             }
         }

--- a/MiniDumper/MiniDumper.cs
+++ b/MiniDumper/MiniDumper.cs
@@ -4,9 +4,12 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using VsChromium.Core.Win32.Debugging;
+using VsChromium.Core.Win32.Processes;
+using Process = VsChromium.Core.Win32.Processes.NativeMethods;
 
 namespace MiniDumper
 {
@@ -72,24 +75,28 @@ namespace MiniDumper
 
         public void DumpOnException(uint threadId, EXCEPTION_RECORD ev)
         {
-            if (ev.ExceptionCode == BREAKPOINT_CODE) {
+            {
                 return;
             }
-            if (ev.ExceptionCode == CLRDBG_NOTIFICATION_EXCEPTION_CODE) {
+            if (ev.ExceptionCode == CLRDBG_NOTIFICATION_EXCEPTION_CODE)
+            {
                 // based on https://social.msdn.microsoft.com/Forums/vstudio/en-US/bca092d4-d2b5-49ef-8bbc-cbce2c67aa89/net-40-firstchance-exception-0x04242420?forum=clr
                 // it's a "notification exception" and can be safely ignored
                 return;
             }
-            if (ev.ExceptionCode == CTRL_C_EXCEPTION_CODE) {
+            if (ev.ExceptionCode == CTRL_C_EXCEPTION_CODE)
+            {
                 // we will also ignore CTRL+C events
                 return;
             }
             // print information about the exception (decode it)
             ClrException managedException = null;
-            foreach (var clrver in target.ClrVersions) {
+            foreach (var clrver in target.ClrVersions)
+            {
                 var runtime = clrver.CreateRuntime();
                 var thr = runtime.Threads.FirstOrDefault(t => t.OSThreadId == threadId);
-                if (thr != null) {
+                if (thr != null)
+                {
                     managedException = thr.CurrentException;
                     break;
                 }
@@ -100,11 +107,13 @@ namespace MiniDumper
 
             PrintTrace("Exception: " + exceptionInfo);
 
-            if (rgxFilter.IsMatch(exceptionInfo)) {
+            if (rgxFilter.IsMatch(exceptionInfo))
+            {
                 byte[] threadContext = new byte[Native.CONTEXT_SIZE];
                 target.DataReader.GetThreadContext(threadId, 0, Native.CONTEXT_SIZE, threadContext);
                 IntPtr pev = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(EXCEPTION_RECORD)));
-                Marshal.StructureToPtr(new EXCEPTION_RECORD{
+                Marshal.StructureToPtr(new EXCEPTION_RECORD
+                {
                     ExceptionAddress = ev.ExceptionAddress,
                     ExceptionFlags = ev.ExceptionFlags,
                     ExceptionCode = ev.ExceptionCode,
@@ -112,13 +121,15 @@ namespace MiniDumper
                     NumberParameters = ev.NumberParameters,
                     ExceptionInformation = ev.ExceptionInformation
                 }, pev, false);
-                var excpointers = new EXCEPTION_POINTERS {
+                var excpointers = new EXCEPTION_POINTERS
+                {
                     ExceptionRecord = pev,
                     ContextRecord = threadContext
                 };
                 IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(excpointers));
                 Marshal.StructureToPtr(excpointers, ptr, false);
-                var excinfo = new MINIDUMP_EXCEPTION_INFORMATION() {
+                var excinfo = new MINIDUMP_EXCEPTION_INFORMATION()
+                {
                     ThreadId = threadId,
                     ClientPointers = false,
                     ExceptionPointers = ptr
@@ -140,6 +151,30 @@ namespace MiniDumper
             MakeActualDump(IntPtr.Zero);
         }
 
+        public void PrintDebugString(OUTPUT_DEBUG_STRING_INFO outputDbgStrInfo)
+        {
+            SafeProcessHandle hProcess = Process.OpenProcess(ProcessAccessFlags.VmRead, false, pid);
+            if (hProcess.IsInvalid)
+                throw new ArgumentException(String.Format("Unable to open process {0}, error {x:8}", pid, Marshal.GetLastWin32Error()));
+
+            var dbgString = new byte[outputDbgStrInfo.nDebugStringLength];
+
+            uint numberOfBytesRead;
+            Process.ReadProcessMemory(hProcess, outputDbgStrInfo.lpDebugStringData, dbgString, outputDbgStrInfo.nDebugStringLength, out numberOfBytesRead);
+
+            if (numberOfBytesRead > 0)
+            {
+                if (outputDbgStrInfo.fUnicode == 0)
+                {
+                    Console.WriteLine("Debug String:\n {0}", Encoding.ASCII.GetString(dbgString));
+                }
+                else
+                {
+                    Console.WriteLine("Debug String:\n {0}", Encoding.Unicode.GetString(dbgString));
+                }
+            }
+        }
+
         private void MakeActualDump(IntPtr excinfo)
         {
             var dumper = new DumpWriter.DumpWriter(logger);
@@ -157,8 +192,10 @@ namespace MiniDumper
             int cnt = 0;
 
             var filename = bfilename;
-            while (true) {
-                if (!File.Exists(filename + ".dmp")) {
+            while (true)
+            {
+                if (!File.Exists(filename + ".dmp"))
+                {
                     break;
                 }
                 cnt++;

--- a/MiniDumper/Properties/AssemblyInfo.cs
+++ b/MiniDumper/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]

--- a/MiniDumper/Properties/AssemblyInfo.cs
+++ b/MiniDumper/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MiniDumper")]
-[assembly: AssemblyCopyright("Copyright © Sasha Goldshtein, Sebastian Solnica 2015")]
+[assembly: AssemblyCopyright("Copyright (C) 2018 Sasha Goldshtein, Sebastian Solnica")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The command line options resemble those from procdump (not all features are yet 
 
 ### Articles about minidumper
 
+- [Minidumper - a better way to create managed memory dumps](http://www.codeproject.com/Articles/1102423/Minidumper-a-better-way-to-create-managed-memory-d)
 - [Creating Smaller, But Still Usable, Dumps of .NET Applications](http://blogs.microsoft.co.il/sasha/2015/08/19/minidumper-smaller-dumps-net-applications/)
 - [More on MiniDumper: Getting the Right Memory Pages for .NET Analysis](http://blogs.microsoft.co.il/sasha/2015/09/30/more-on-minidumper-getting-the-right-memory-pages-for-net-analysis/)
 - [New features coming to minidumper](https://lowleveldesign.wordpress.com/2015/12/21/new-features-coming-to-minidumper)


### PR DESCRIPTION
Fixes and changes:
- fixed problem with missing debug messages (by @kishan3034)
- problem with the missing process name when creating immediate dumps
- a dump will be saved to the current folder (not the folder where MiniDumper is installed)