### PR TITLE
Memory commit threshold in MB at which to create a dump.

### DIFF
--- a/MiniDumper/CommandLineOptions.cs
+++ b/MiniDumper/CommandLineOptions.cs
@@ -43,6 +43,9 @@ namespace MiniDumper
         [Option('c', HelpText = "Start the process in a new console window.")]
         public bool StartProcessInNewConsoleWindow { get; set; }
 
+        [Option('m', HelpText = "Memory commit threshold in MB at which to create a dump.")]
+        public int MemoryCommitThreshold { get; set; }
+
         [Value(0, Required = true, HelpText = "PID or process name")]
         public string ProcessInfo { get; set; }
 

--- a/MiniDumper/CommandLineOptions.cs
+++ b/MiniDumper/CommandLineOptions.cs
@@ -57,7 +57,7 @@ namespace MiniDumper
 
         public bool NoDumpOptionSelected
         {
-            get { return !DumpOnProcessTerminate && DumpOnException == 0; }
+            get { return !DumpOnProcessTerminate && DumpOnException == 0 && !(MemoryCommitThreshold.HasValue || MemoryCommitDrops.HasValue); }
         }
     }
 }

--- a/MiniDumper/CommandLineOptions.cs
+++ b/MiniDumper/CommandLineOptions.cs
@@ -29,7 +29,7 @@ namespace MiniDumper
         public bool Verbose { get; set; }
 
         [Option('p', HelpText = "Memory commit threshold in MB at which to create a dump.")]
-        public int? MemoryCommitThreshold { get; set; }
+        public uint? MemoryCommitThreshold { get; set; }
 
         [Option('f', HelpText = "Filter on the content of exceptions and debug logging. Wildcards (*) are supported.")]
         public string ExceptionFilter { get; set; }

--- a/MiniDumper/CommandLineOptions.cs
+++ b/MiniDumper/CommandLineOptions.cs
@@ -62,7 +62,7 @@ namespace MiniDumper
 
         public bool NeedAttachDebugger
         {
-            get { return DumpOnProcessTerminate || DumpOnException == 0; }
+            get { return DumpOnProcessTerminate || DumpOnException == 1 || DumpOnException == 2; }
         }
     }
 }

--- a/MiniDumper/CommandLineOptions.cs
+++ b/MiniDumper/CommandLineOptions.cs
@@ -28,6 +28,9 @@ namespace MiniDumper
         [Option('l', HelpText = "Display the debug logging of the process + diagnostics info from the minidumper.")]
         public bool Verbose { get; set; }
 
+        [Option('p', HelpText = "Memory commit threshold in MB at which to create a dump.")]
+        public int? MemoryCommitThreshold { get; set; }
+
         [Option('f', HelpText = "Filter on the content of exceptions and debug logging. Wildcards (*) are supported.")]
         public string ExceptionFilter { get; set; }
 

--- a/MiniDumper/CommandLineOptions.cs
+++ b/MiniDumper/CommandLineOptions.cs
@@ -28,8 +28,11 @@ namespace MiniDumper
         [Option('l', HelpText = "Display the debug logging of the process + diagnostics info from the minidumper.")]
         public bool Verbose { get; set; }
 
-        [Option('p', HelpText = "Memory commit threshold in MB at which to create a dump.")]
+        [Option('y', HelpText = "Memory commit threshold in MB at which to create a dump.")]
         public uint? MemoryCommitThreshold { get; set; }
+        
+        [Option('z', HelpText = "Memory commit threshold in MB at which to create a dump.")]
+        public uint? MemoryCommitDrops { get; set; }
 
         [Option('f', HelpText = "Filter on the content of exceptions and debug logging. Wildcards (*) are supported.")]
         public string ExceptionFilter { get; set; }

--- a/MiniDumper/CommandLineOptions.cs
+++ b/MiniDumper/CommandLineOptions.cs
@@ -43,9 +43,6 @@ namespace MiniDumper
         [Option('c', HelpText = "Start the process in a new console window.")]
         public bool StartProcessInNewConsoleWindow { get; set; }
 
-        [Option('m', HelpText = "Memory commit threshold in MB at which to create a dump.")]
-        public int MemoryCommitThreshold { get; set; }
-
         [Value(0, Required = true, HelpText = "PID or process name")]
         public string ProcessInfo { get; set; }
 

--- a/MiniDumper/CommandLineOptions.cs
+++ b/MiniDumper/CommandLineOptions.cs
@@ -59,5 +59,10 @@ namespace MiniDumper
         {
             get { return !DumpOnProcessTerminate && DumpOnException == 0 && !(MemoryCommitThreshold.HasValue || MemoryCommitDrops.HasValue); }
         }
+
+        public bool NeedAttachDebugger
+        {
+            get { return DumpOnProcessTerminate || DumpOnException == 0; }
+        }
     }
 }

--- a/MiniDumper/Debugger.cs
+++ b/MiniDumper/Debugger.cs
@@ -65,6 +65,11 @@ namespace MiniDumper
                     return;
                 }
 
+                if (_options.MemoryCommitThreshold.HasValue)
+                {
+                    miniDumper.MemoryCommitThreshold(_options.MemoryCommitThreshold.Value);
+                }
+
                 while (!_detached) {
                     var debugEvent = WaitForDebugEvent(1000);
                     if (_shouldDeatch) {

--- a/MiniDumper/Debugger.cs
+++ b/MiniDumper/Debugger.cs
@@ -65,8 +65,6 @@ namespace MiniDumper
                     return;
                 }
 
-
-
                 while (!_detached) {
                     var debugEvent = WaitForDebugEvent(1000);
                     if (_shouldDeatch) {

--- a/MiniDumper/Debugger.cs
+++ b/MiniDumper/Debugger.cs
@@ -65,9 +65,9 @@ namespace MiniDumper
                     return;
                 }
 
-                if (_options.MemoryCommitThreshold.HasValue)
+                if (_options.MemoryCommitThreshold.HasValue || _options.MemoryCommitDrops.HasValue)
                 {
-                    miniDumper.MemoryCommitThreshold(_options.MemoryCommitThreshold.Value);
+                    miniDumper.MemoryCommitThreshold(_options.MemoryCommitThreshold.Value, _options.MemoryCommitDrops);
                 }
 
                 while (!_detached) {

--- a/MiniDumper/Debugger.cs
+++ b/MiniDumper/Debugger.cs
@@ -65,6 +65,8 @@ namespace MiniDumper
                     return;
                 }
 
+
+
                 while (!_detached) {
                     var debugEvent = WaitForDebugEvent(1000);
                     if (_shouldDeatch) {

--- a/MiniDumper/Debugger.cs
+++ b/MiniDumper/Debugger.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using VsChromium.Core.Win32;
 using VsChromium.Core.Win32.Debugging;
 using VsChromium.Core.Win32.Processes;
@@ -17,10 +18,13 @@ namespace MiniDumper
     {
         static void Main(string[] args)
         {
-            try {
+            try
+            {
                 var result = Parser.Default.ParseArguments<CommandLineOptions>(args);
                 result.WithParsed(options => new Debugger(options).TakeDumps());
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 Console.Error.WriteLine("ERROR: {0}", ex.Message);
             }
         }
@@ -32,6 +36,7 @@ namespace MiniDumper
         private bool _shouldDeatch;
         private int _pid;
         private string _processName;
+        public static bool IsPollingCompleted = false;
 
         public Debugger(CommandLineOptions options)
         {
@@ -48,38 +53,58 @@ namespace MiniDumper
             ShowBanner();
 
             // setup Ctrl+C listener
-            Console.CancelKeyPress += (o, ev) => {
+            Console.CancelKeyPress += (o, ev) =>
+            {
                 Console.WriteLine("Ctrl + C received - detaching from a process");
                 ev.Cancel = true;
-                _shouldDeatch = true; 
+                _shouldDeatch = true;
             };
+
             WaitForDebugEvents();
         }
 
         private void WaitForDebugEvents()
         {
-            using (var miniDumper = CreateMiniDumper()) {
-                if (_options.NoDumpOptionSelected) {
+            using (var miniDumper = CreateMiniDumper())
+            {
+                if (_options.NoDumpOptionSelected)
+                {
                     miniDumper.DumpWithoutReason();
                     DetachProcess();
+                    CheckNumberOfDumpsTaken(miniDumper);
                     return;
                 }
 
                 if (_options.MemoryCommitThreshold.HasValue || _options.MemoryCommitDrops.HasValue)
                 {
-                    miniDumper.MemoryCommitThreshold(_options.MemoryCommitThreshold.Value, _options.MemoryCommitDrops);
+                    bool isTimerSet = false;
+                    DetachProcess();
+
+                    while (!IsPollingCompleted)
+                    {
+                        if (!isTimerSet)
+                            miniDumper.MemoryCommitThreshold(_options.MemoryCommitThreshold.Value, _options.MemoryCommitDrops, ref isTimerSet);
+                    }
+
+                    CheckNumberOfDumpsTaken(miniDumper);
+                    return;
                 }
 
-                while (!_detached) {
+                while (!_detached)
+                {
                     var debugEvent = WaitForDebugEvent(1000);
-                    if (_shouldDeatch) {
+                    if (_shouldDeatch)
+                    {
                         DetachProcess();
                         return;
                     }
-                    if (debugEvent.HasValue) {
-                        switch (debugEvent.Value.dwDebugEventCode) {
+                    if (debugEvent.HasValue)
+                    {
+                        switch (debugEvent.Value.dwDebugEventCode)
+                        {
                             case DEBUG_EVENT_CODE.EXIT_PROCESS_DEBUG_EVENT:
-                                if (_options.DumpOnProcessTerminate) {
+                                if (_options.DumpOnProcessTerminate)
+                                {
                                     miniDumper.DumpOnProcessExit(debugEvent.Value.ExitProcess.dwExitCode);
                                 }
                                 _shouldDeatch = true;
@@ -87,7 +112,8 @@ namespace MiniDumper
                             case DEBUG_EVENT_CODE.EXCEPTION_DEBUG_EVENT:
                                 var exception = debugEvent.Value.Exception;
                                 if (_options.DumpOnException == 1 && exception.dwFirstChance == 1 ||
-                                    _options.DumpOnException == 2 && exception.dwFirstChance == 0) {
+                                    _options.DumpOnException == 2 && exception.dwFirstChance == 0)
+                                {
                                     miniDumper.DumpOnException((uint)debugEvent.Value.dwThreadId, exception.ExceptionRecord);
                                 }
                                 break;
@@ -100,20 +126,24 @@ namespace MiniDumper
                             default:
                                 break;
                         }
-                        if (!_shouldDeatch && miniDumper.NumberOfDumpsTaken >= _options.NumberOfDumps) {
+                        if (!_shouldDeatch && miniDumper.NumberOfDumpsTaken >= _options.NumberOfDumps)
+                        {
                             Console.WriteLine("Number of dumps exceeded the specified limit - detaching.");
                             _shouldDeatch = true;
                         }
-                        if (_shouldDeatch) {
+                        if (_shouldDeatch)
+                        {
                             DetachProcess();
                             return;
                         }
-                        if (_detached) {
+                        if (_detached)
+                        {
                             return;
                         }
                         var continueStatus = HandleDebugEvent(debugEvent.Value);
                         if (!DebuggingNativeMethods.ContinueDebugEvent(debugEvent.Value.dwProcessId,
-                            debugEvent.Value.dwThreadId, continueStatus)) {
+                            debugEvent.Value.dwThreadId, continueStatus))
+                        {
                             throw new LastWin32ErrorException("Error in ContinueDebugEvent");
                         }
                     }
@@ -121,11 +151,23 @@ namespace MiniDumper
             }
         }
 
+        private void CheckNumberOfDumpsTaken(MiniDumper miniDumper)
+        {
+            if (miniDumper.NumberOfDumpsTaken == _options.NumberOfDumps)
+                return;
+
+            while (miniDumper.NumberOfDumpsTaken < _options.NumberOfDumps)
+            {
+                miniDumper.DumpWithoutReason();
+            }
+        }
+
         private static DEBUG_EVENT? WaitForDebugEvent(uint timeout)
         {
             DEBUG_EVENT debugEvent;
             var success = DebuggingNativeMethods.WaitForDebugEvent(out debugEvent, timeout);
-            if (!success) {
+            if (!success)
+            {
                 int hr = Marshal.GetHRForLastWin32Error();
                 if (hr == HResults.HR_ERROR_SEM_TIMEOUT)
                     return null;
@@ -137,7 +179,8 @@ namespace MiniDumper
 
         private static CONTINUE_STATUS HandleDebugEvent(DEBUG_EVENT value)
         {
-            if (value.dwDebugEventCode == DEBUG_EVENT_CODE.EXCEPTION_DEBUG_EVENT) {
+            if (value.dwDebugEventCode == DEBUG_EVENT_CODE.EXCEPTION_DEBUG_EVENT)
+            {
                 return CONTINUE_STATUS.DBG_EXCEPTION_NOT_HANDLED;
             }
             return CONTINUE_STATUS.DBG_CONTINUE;
@@ -145,16 +188,19 @@ namespace MiniDumper
 
         static void ValidateOptions(CommandLineOptions options)
         {
-            if (string.IsNullOrEmpty(options.ProcessInfo)) {
+            if (string.IsNullOrEmpty(options.ProcessInfo))
+            {
                 throw new ArgumentException("Either a process id or process name is required");
             }
             // file name and dump folder
             if (options.DumpFolderForNewlyStartedProcess != null &&
-                !Directory.Exists(options.DumpFolderForNewlyStartedProcess)) {
+                !Directory.Exists(options.DumpFolderForNewlyStartedProcess))
+            {
                 throw new ArgumentException("The specified dump folder does not exist.");
             }
             if (options.NoDumpOptionSelected && !string.IsNullOrEmpty(
-                options.DumpFolderForNewlyStartedProcess)) {
+                options.DumpFolderForNewlyStartedProcess))
+            {
                 throw new ArgumentException("Option to create an immediate dump when starting a process is not supported.");
             }
         }
@@ -165,48 +211,62 @@ namespace MiniDumper
             _processName = null;
 
             int pid;
-            if (int.TryParse(_options.ProcessInfo, out pid)) {
+            if (int.TryParse(_options.ProcessInfo, out pid))
+            {
                 _pid = pid;
-            } else {
+            }
+            else
+            {
                 // not numeric - let's try to find it by name
                 var procs = Process.GetProcesses();
-                foreach (var proc in procs) {
-                    try {
-                        if (_options.ProcessInfo.Equals(proc.MainModule.ModuleName, StringComparison.OrdinalIgnoreCase)) {
+                foreach (var proc in procs)
+                {
+                    try
+                    {
+                        if (_options.ProcessInfo.Equals(proc.MainModule.ModuleName, StringComparison.OrdinalIgnoreCase))
+                        {
                             _pid = proc.Id;
                             break;
                         }
-                    } catch {
+                    }
+                    catch
+                    {
                         // just ignore it
                     }
                 }
             }
-            if (_pid > 0) {
+            if (_pid > 0)
+            {
                 // process found - let's attach to it
-                if (!DebuggingNativeMethods.DebugActiveProcess(_pid)) {
+                if (!DebuggingNativeMethods.DebugActiveProcess(_pid))
+                {
                     Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
                 }
                 _processName = GetProcessName(_pid);
                 return;
             }
-            if (spawnNew) {
+            if (spawnNew)
+            {
                 // final try - let's try creating it (but only if -x option is set)
                 var commandLine = _options.ProcessInfo + " " + string.Join(" ", _options.Args ?? new string[0]);
 
                 var startupInfo = new STARTUPINFO();
                 var processInformation = new PROCESS_INFORMATION();
                 var processCreationFlags = ProcessCreationFlags.DEBUG_ONLY_THIS_PROCESS;
-                if (_options.StartProcessInNewConsoleWindow) {
+                if (_options.StartProcessInNewConsoleWindow)
+                {
                     processCreationFlags |= ProcessCreationFlags.CREATE_NEW_CONSOLE;
                 }
                 bool res = ProcessNativeMethods.CreateProcess(null, new StringBuilder(commandLine),
-                    null, null, false, processCreationFlags, IntPtr.Zero, null, 
+                    null, null, false, processCreationFlags, IntPtr.Zero, null,
                     startupInfo, processInformation);
-                if (!res) {
+                if (!res)
+                {
                     Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
                 }
 
-                if (!DebuggingNativeMethods.DebugSetProcessKillOnExit(false)) {
+                if (!DebuggingNativeMethods.DebugSetProcessKillOnExit(false))
+                {
                     Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
                 }
                 _pid = processInformation.dwProcessId;
@@ -218,10 +278,12 @@ namespace MiniDumper
 
         void DetachProcess()
         {
-            if (_detached) {
+            if (_detached)
+            {
                 return;
             }
-            if (!DebuggingNativeMethods.DebugActiveProcessStop(_pid)) {
+            if (!DebuggingNativeMethods.DebugActiveProcessStop(_pid))
+            {
                 _logger.Write("Exception occured when detaching from the process: {0}",
                     Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()));
             }

--- a/MiniDumper/MiniDumper.cs
+++ b/MiniDumper/MiniDumper.cs
@@ -178,6 +178,11 @@ namespace MiniDumper
             }
         }
 
+        public void MemoryCommitThreshold()
+        {
+
+        }
+
         private void MakeActualDump(IntPtr excinfo)
         {
             var dumper = new DumpWriter.DumpWriter(logger);

--- a/MiniDumper/MiniDumper.cs
+++ b/MiniDumper/MiniDumper.cs
@@ -182,21 +182,17 @@ namespace MiniDumper
 
         public void MemoryCommitThreshold(int commitThreshold)
         {
-            Debug.Assert(commitThreshold != 0, "commitThreshold is zero");
             System.Timers.Timer aTimer = new System.Timers.Timer();
             aTimer.Interval = 1000;
             aTimer.Elapsed += (sender, e) => OnTimedEvent(sender, e, commitThreshold); ;
             aTimer.AutoReset = true;
             aTimer.Enabled = true;
-
         }
 
         private void OnTimedEvent(Object source, ElapsedEventArgs e, int commitThreshold)
         {
            var process = Process.GetProcessById(pid);
             double privateMemory = (process.PrivateMemorySize64 / 1024) / 1024;
-            Console.WriteLine($"PrivateMemory {(int)privateMemory}MB");
-
             if (privateMemory >= commitThreshold)
             {
                 var timer = source as System.Timers.Timer;

--- a/MiniDumper/MiniDumper.cs
+++ b/MiniDumper/MiniDumper.cs
@@ -178,11 +178,6 @@ namespace MiniDumper
             }
         }
 
-        public void MemoryCommitThreshold()
-        {
-
-        }
-
         private void MakeActualDump(IntPtr excinfo)
         {
             var dumper = new DumpWriter.DumpWriter(logger);

--- a/MiniDumper/MiniDumper.cs
+++ b/MiniDumper/MiniDumper.cs
@@ -229,7 +229,6 @@ namespace MiniDumper
         private void OnTimedEvent()
         {
             processCommit = GetProcessCommit(hProcess);
-
             if ((CommitThreshold.HasValue && processCommit >= CommitThreshold) || (CommitDrops.HasValue && processCommit >= CommitDrops))
             {
                 Debug.Write(CommitThreshold.HasValue ? $"Commit:\t >= {CommitDrops / 1024 / 1024}MB" : $"Commit:\t <= {CommitDrops / 1024 / 1024}MB");

--- a/MiniDumper/MiniDumper.csproj
+++ b/MiniDumper/MiniDumper.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Win32\Processes\NativeStructs.cs" />
     <Compile Include="Win32\Processes\ProcessCreationFlags.cs" />
     <Compile Include="Win32\Processes\PROCESS_INFORMATION.cs" />
+    <Compile Include="Win32\Processes\PROCESS_MEMORY_COUNTERS_EX.cs" />
     <Compile Include="Win32\Processes\SafeProcessHandle.cs" />
     <Compile Include="Win32\Processes\SafeThreadHandle.cs" />
     <Compile Include="Win32\Processes\Startupinfo.cs" />

--- a/MiniDumper/Win32/Processes/NativeMethods.cs
+++ b/MiniDumper/Win32/Processes/NativeMethods.cs
@@ -2,73 +2,80 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+using MiniDumper.Win32.Processes;
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using VsChromium.Core.Win32.Interop;
 
-namespace VsChromium.Core.Win32.Processes {
-  static class NativeMethods {
-    [DllImport("shell32.dll", SetLastError = true)]
-    public static extern IntPtr CommandLineToArgvW(
-      [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine,
-      out int pNumArgs);
+namespace VsChromium.Core.Win32.Processes
+{
+    static class NativeMethods
+    {
+        [DllImport("shell32.dll", SetLastError = true)]
+        public static extern IntPtr CommandLineToArgvW(
+          [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine,
+          out int pNumArgs);
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Ansi, SetLastError = true)]
-    public static extern IntPtr GetCurrentProcess();
+        [DllImport("kernel32.dll", CharSet = CharSet.Ansi, SetLastError = true)]
+        public static extern IntPtr GetCurrentProcess();
 
-    [DllImport("kernel32.dll", BestFitMapping = false, CharSet = CharSet.Auto, SetLastError = true)]
-    public static extern bool CreateProcess(
-      [MarshalAs(UnmanagedType.LPTStr)] string lpApplicationName,
-      StringBuilder lpCommandLine,
-      SecurityAttributes lpProcessAttributes,
-      SecurityAttributes lpThreadAttributes,
-      bool bInheritHandles,
-      ProcessCreationFlags dwCreationFlags,
-      IntPtr lpEnvironment,
-      [MarshalAs(UnmanagedType.LPTStr)] string lpCurrentDirectory,
-      STARTUPINFO lpStartupInfo,
-      [In, Out]
+        [DllImport("kernel32.dll", BestFitMapping = false, CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern bool CreateProcess(
+          [MarshalAs(UnmanagedType.LPTStr)] string lpApplicationName,
+          StringBuilder lpCommandLine,
+          SecurityAttributes lpProcessAttributes,
+          SecurityAttributes lpThreadAttributes,
+          bool bInheritHandles,
+          ProcessCreationFlags dwCreationFlags,
+          IntPtr lpEnvironment,
+          [MarshalAs(UnmanagedType.LPTStr)] string lpCurrentDirectory,
+          STARTUPINFO lpStartupInfo,
+          [In, Out]
       PROCESS_INFORMATION lpProcessInformation);
 
-    [DllImport("ntdll.dll", SetLastError = true)]
-    public static extern int NtReadVirtualMemory(
-        SafeProcessHandle hProcess,
-        IntPtr baseAddress,
-        [Out] byte[] buffer,
-        uint size,
-        out uint lpNumberOfBytesRead);
+        [DllImport("ntdll.dll", SetLastError = true)]
+        public static extern int NtReadVirtualMemory(
+            SafeProcessHandle hProcess,
+            IntPtr baseAddress,
+            [Out] byte[] buffer,
+            uint size,
+            out uint lpNumberOfBytesRead);
 
-    [DllImport("ntdll.dll", SetLastError = true)]
-    public static extern int NtWow64ReadVirtualMemory64(
-        SafeProcessHandle hProcess,
-        ulong baseAddress,
-        IntPtr buffer,
-        ulong bufferSize,
-        out ulong lpNumberOfBytesRead);
+        [DllImport("ntdll.dll", SetLastError = true)]
+        public static extern int NtWow64ReadVirtualMemory64(
+            SafeProcessHandle hProcess,
+            ulong baseAddress,
+            IntPtr buffer,
+            ulong bufferSize,
+            out ulong lpNumberOfBytesRead);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    public static extern SafeProcessHandle OpenProcess(
-      [MarshalAs(UnmanagedType.U4)] ProcessAccessFlags dwDesiredAccess,
-      [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
-      int dwProcessId);
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern SafeProcessHandle OpenProcess(
+          [MarshalAs(UnmanagedType.U4)] ProcessAccessFlags dwDesiredAccess,
+          [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
+          int dwProcessId);
 
-    [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.StdCall,
-      CharSet = CharSet.Unicode)]
-    public static extern uint QueryFullProcessImageName(
-      SafeProcessHandle hProcess,
-      [MarshalAs(UnmanagedType.U4)] ProcessQueryImageNameMode flags,
-      [Out] StringBuilder lpImageName, ref int size);
+        [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.StdCall,
+          CharSet = CharSet.Unicode)]
+        public static extern uint QueryFullProcessImageName(
+          SafeProcessHandle hProcess,
+          [MarshalAs(UnmanagedType.U4)] ProcessQueryImageNameMode flags,
+          [Out] StringBuilder lpImageName, ref int size);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool ReadProcessMemory(SafeProcessHandle hProcess, IntPtr lpBaseAddress,
-      [Out] byte[] buffer, uint size, out UInt32 lpNumberOfBytesRead);
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ReadProcessMemory(SafeProcessHandle hProcess, IntPtr lpBaseAddress,
+          [Out] byte[] buffer, uint size, out UInt32 lpNumberOfBytesRead);
 
-    [DllImport("ntdll.dll", SetLastError = true)]
-    public static extern int NtQueryInformationProcess(SafeProcessHandle hProcess, ProcessInfoClass pic, ref ProcessBasicInformation pbi, int cb, out int pSize);
+        [DllImport("ntdll.dll", SetLastError = true)]
+        public static extern int NtQueryInformationProcess(SafeProcessHandle hProcess, ProcessInfoClass pic, ref ProcessBasicInformation pbi, int cb, out int pSize);
 
-    [DllImport("ntdll.dll", SetLastError = true)]
-    public static extern int NtWow64QueryInformationProcess64(SafeProcessHandle hProcess, ProcessInfoClass pic, ref ProcessBasicInformationWow64 pbi, int cb, out int pSize);
-  }
+        [DllImport("ntdll.dll", SetLastError = true)]
+        public static extern int NtWow64QueryInformationProcess64(SafeProcessHandle hProcess, ProcessInfoClass pic, ref ProcessBasicInformationWow64 pbi, int cb, out int pSize);
+
+        [DllImport("psapi.dll", SetLastError = true)]
+       public static extern bool GetProcessMemoryInfo(SafeProcessHandle hProcess, out PROCESS_MEMORY_COUNTERS_EX counters, uint size);
+        
+    }    
 }

--- a/MiniDumper/Win32/Processes/PROCESS_MEMORY_COUNTERS_EX.cs
+++ b/MiniDumper/Win32/Processes/PROCESS_MEMORY_COUNTERS_EX.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace MiniDumper.Win32.Processes
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct PROCESS_MEMORY_COUNTERS_EX
+    {
+        public uint cb;
+        public uint PageFaultCount;
+        public UIntPtr PeakWorkingSetSize;
+        public UIntPtr WorkingSetSize;
+        public UIntPtr QuotaPeakPagedPoolUsage;
+        public UIntPtr QuotaPagedPoolUsage;
+        public UIntPtr QuotaPeakNonPagedPoolUsage;
+        public UIntPtr QuotaNonPagedPoolUsage;
+        public UIntPtr PagefileUsage;
+        public UIntPtr PeakPagefileUsage;
+        public UIntPtr PrivateUsage;
+    }
+}


### PR DESCRIPTION
Hi @lowleveldesign and @goldshtn 

will you  suggest some better option than 'p' in CommandLineOptions.cs line 31

`[Option('p', HelpText = "Memory commit threshold in MB at which to create a dump.")]`
`public int? MemoryCommitThreshold { get; set; }`

will you please guide me better approach than what i Implemented.  in MiniDumper.cs 

`public void MemoryCommitThreshold(int commitThreshold)`
 `private void OnTimedEvent(Object source, ElapsedEventArgs e, int commitThreshold)`

Thanks
kishan